### PR TITLE
Avoid enforcing courier font.

### DIFF
--- a/mcorelisting.tex
+++ b/mcorelisting.tex
@@ -1,6 +1,5 @@
 \usepackage{listings}
 \usepackage{xcolor}
-\usepackage{courier}
 
 \def \mcorefontsize {\normalsize}
 


### PR DESCRIPTION
I propose that font selection should be up to the user. Having `\usepackage{courier}` makes all uses of `\texttt{...}` and friends use the courier font which might not always be desirable.